### PR TITLE
Change function name to getLittledataAttribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # nacelle-littledata-nuxt-module
 
-Adds Nuxt plugin for integrating [LittleData](https://www.littledata.io/) in your [Nacelle](https://getnacelle.com/) Nuxt project.
+Adds a Nuxt plugin for integrating [Littledata](https://www.littledata.io/) in your [Nacelle](https://getnacelle.com/) Nuxt project. This plugin makes it easier to add the Google Analytics clientId to checkout attributes, as documented in step 4 of Littledata's [headless setup guide](https://headlessdemo.littledata.io/).
 
 ## Requirements
 
-- A Nacelle project set up locally. See https://docs.getnacelle.com for getting started.
-- Google Analytics set up. See https://docs.getnacelle.com/deployment/deployment-netlify.html#facebook-google-anaytics-tracker-variables for getting started
-- LittleData [setup](https://headlessdemo.littledata.io/).
+- A Nacelle project [set up locally](https://docs.getnacelle.com/quick-start.html).
+- Google Analytics [set up for Nacelle](https://docs.getnacelle.com/deployment/deployment-netlify.html#facebook-google-anaytics-tracker-variables).
+- Littledata [setup](https://headlessdemo.littledata.io/).
 
 ### Add Module to Nacelle
 
-Once you have Nacelle, Google Analytics and LittleData set up you can install this module in your project from `npm`:
+Once you have Nacelle, Google Analytics and Littledata set up you can install this module in your project from `npm`:
 
 ```
 npm install @nacelle/nacelle-littledata-nuxt-module --save
@@ -28,14 +28,14 @@ modules: [
 ],
 ```
 
-Then add the little data client id to your checkout process in `cart.js` by using the new function that has been added to your project `$getLittleDataMetafield` like so:
+Then add the Google Analytics client ID to your checkout process in `cart.js` by using the new function that has been added to your project `$getLittledataAttribute` like so:
 
 ```
 const processCheckoutObject = await this.$nacelle.checkout
   .process({
     cartItems: getters.checkoutLineItems,
     checkoutId: getters.checkoutIdForBackend,
-    metafields: [await this.$getLittleDataMetafield()]
+    atrributes: [await this.$getLittledataAttribute()]
   })
   ...
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const processCheckoutObject = await this.$nacelle.checkout
   .process({
     cartItems: getters.checkoutLineItems,
     checkoutId: getters.checkoutIdForBackend,
-    atrributes: [await this.$getLittledataAttribute()]
+    customAttributes: [await this.$getLittledataAttribute()]
   })
   ...
 ```

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ modules: [
 ],
 ```
 
-Then add the Google Analytics client ID to your checkout process in `cart.js` by using the new function that has been added to your project `$getLittledataAttribute` like so:
+Then add the Google Analytics client ID to your checkout process in `cart.js` by using the new function that has been added to your project `$getLittledataMetafield` like so:
 
 ```
 const processCheckoutObject = await this.$nacelle.checkout
   .process({
     cartItems: getters.checkoutLineItems,
     checkoutId: getters.checkoutIdForBackend,
-    customAttributes: [await this.$getLittledataAttribute()]
+    metafields: [await this.$getLittledataMetafield()]
   })
   ...
 ```

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -38,7 +38,7 @@ export const getGoogleClientId = () => {
 };
 
 export default (_ctx, inject) => {
-  inject("getLittledataAttribute", async () => {
+  inject("getLittledataMetafield", async () => {
     return { key: "google-clientID", value: await getGoogleClientId() };
   });
 };

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -22,12 +22,12 @@ export const getGoogleClientId = () => {
 
           return resolve(clientId);
         } catch (err) {
-          reject(`Google Client Id not found: ${err}`);
+          reject(`Google Analytics Client ID not found: ${err}`);
         }
       });
     } else {
       console.warn(
-        "Could not initiate Littledata due to missing `window.ga` - " +
+        "Could not send GA client ID to Littledata due to missing `window.ga` - " +
           "this can be a result of a browser extension which blocks GA, " +
           "or a missing `nacelle.gaID` in nuxt.config.js"
       );
@@ -38,7 +38,7 @@ export const getGoogleClientId = () => {
 };
 
 export default (_ctx, inject) => {
-  inject("getLittleDataMetafield", async () => {
+  inject("getLittledataAttribute", async () => {
     return { key: "google-clientID", value: await getGoogleClientId() };
   });
 };


### PR DESCRIPTION
@NWRichmond Our https://headlessdemo.littledata.io/ requires the GA client ID to be sent with checkout [customAttributes](https://shopify.dev/docs/storefront-api/reference/checkouts/checkout). See [this code example](https://github.com/littledata/headless-shopify-demo/blob/f22961a7a12bd78fbd42ae987e05dd4e8c2593c8/server/checkout/methods.js#L45)


I've changed the function name changes to be clear that the GA client ID is added to checkout attributes not metafields, but i'm not clear if the $nacelle.checkout.process method will accept this param. Or are metafields forwarded as customAttributes?

Also fixed typos for brand names